### PR TITLE
Remove compilation warnings for zephyr 2.5.0 and suppress debug output

### DIFF
--- a/client_libraries/c/include/pb_zephyr.h
+++ b/client_libraries/c/include/pb_zephyr.h
@@ -3,12 +3,6 @@
 
 #include <stddef.h>
 
-# if __WORDSIZE == 64
-#  define UINT64_C(c)        c ## UL
-# else
-#  define UINT64_C(c)        c ## ULL
-# endif
-
 char * strndup (const char *s, size_t n);
 char * strdup (const char *s);
 

--- a/client_libraries/c/include/tahu.h
+++ b/client_libraries/c/include/tahu.h
@@ -29,7 +29,8 @@
 #define _SPARKPLUGLIB_H_
 
 // Enable/disable debug messages
-#define SPARKPLUG_DEBUG 1
+// TODO: adds Kconfig entry to enable this flag
+//#define SPARKPLUG_DEBUG 1
 
 #ifdef SPARKPLUG_DEBUG
 #define DEBUG_PRINT(...) printf(__VA_ARGS__)


### PR DESCRIPTION
- Remove debug output
- Suppress compilation warnings due to macro being already defined